### PR TITLE
fix: update args

### DIFF
--- a/msw.js
+++ b/msw.js
@@ -37,8 +37,8 @@ function registerMockRoutes(...mocks) {
       throw new Error(`Unsupported method ${method}`);
     }
     
-    handlers.push(rest[method](endpoint, async (res, req, context) => {
-      const response = await handler({request: req});
+    handlers.push(rest[method](endpoint, async ({cookies, params, request}) => {
+      const response = await handler({request, cookies, params});
 
       return response;
     }))


### PR DESCRIPTION
msw doesnt pass `(req, res, context)` anymore, it passes `({cookies, params, request})`.

Passing `cookies` and `params` to the handler kind of breaks the nice clean api we have (request -> handler -> response), but I think are essential for users to adequately be able to mock based on cookies and params. So this also means we'd need to pass cookies and params in next versions of whatever mocking solution we use. For `params` this is no big deal because we can just use `URLPattern` to achieve it in our integration layer, ~~but I'd like to understand how MSW gets the cookies off the request before we merge. I've asked this question to the maintainer of MSW on discord.~~

Found it, its just `request.headers.get('cookie')` and reading from `document.cookie` and then turning it into an object. 

Feel free to review/merge if you agree